### PR TITLE
取消证件配置、证件信息对 ../carManCert/*.js 的依赖

### DIFF
--- a/src/main/java/cn/bc/cert/web/struts2/CertInfosAction.java
+++ b/src/main/java/cn/bc/cert/web/struts2/CertInfosAction.java
@@ -58,9 +58,8 @@ public class CertInfosAction extends ViewAction<Map<String, Object>> {
   @Override
   protected String getHtmlPageJs() {
     return this.getModuleContextPath() + "/certInfo/view.js"+","+this.getContextPath()+"/bc-business/bs.js"
-        +","+this.getContextPath()+"/modules/bc/cert/certCfg/form.js"+","+this.getContextPath()+"/bc-business/carManCert/view.js"
-        +","+this.getContextPath()+"/bc/form/api.js"+","+this.getContextPath() + "/modules/bc/cert/api.js"
-        +","+this.getContextPath()+"/bc-business/carManCert/form.js";
+        +","+this.getContextPath()+"/modules/bc/cert/certCfg/form.js"
+        +","+this.getContextPath()+"/bc/form/api.js"+","+this.getContextPath() + "/modules/bc/cert/api.js";
   }
 
   /** 页面加载后调用的js初始化方法 */

--- a/src/main/resources/META-INF/resources/modules/bc/cert/certCfg/form.jsp
+++ b/src/main/resources/META-INF/resources/modules/bc/cert/certCfg/form.jsp
@@ -2,7 +2,7 @@
 <%@ taglib prefix="s" uri="/struts-tags"%>
 <div title='<s:text name="certForm.title"/>' data-type='form' class="bc-page"
   data-saveUrl='<s:url value="/modules/bc/cert/certCfg/save" />'
-  data-js='js:bc_identity,<s:url value="/bc-business/bs.js" />,<s:url value="/modules/bc/cert/api.js" />,<s:url value="/modules/bc/cert/certCfg/form.js" />,<s:url value="/bc-business/carManCert/view.js" />,<s:url value="/bc/form/api.js" />,<s:url value="/bc-business/carManCert/carManCert.js" />,<s:url value="/bc-business/carManCert/form.js" />'
+  data-js='js:bc_identity,<s:url value="/bc-business/bs.js" />,<s:url value="/modules/bc/cert/api.js" />,<s:url value="/modules/bc/cert/certCfg/form.js" />,<s:url value="/bc/form/api.js" />'
   data-initMethod='bc.certCfgForm.init'
   data-option='<s:property value="formPageOption"/>' style="overflow-y:auto;">
   <s:form name="certCfgForm" theme="simple" >


### PR DESCRIPTION
当前在新建或打开证件配置或打开证件信息时，会出现：
请求 http://.../carManCert/view.js 404 错误。
然后在证件配置表单与证件信息视图中没有找到有需要用到carManCert/*.js 的地方，且去掉后就可以正常打开、新建，
所以就去掉了对 ../carManCert/*.js 的引入。