### PR TITLE
添加获取证件配置的选项列表实现和保留禁用司机证件的历史信息

### DIFF
--- a/src/main/java/cn/bc/cert/service/CertCfgService.java
+++ b/src/main/java/cn/bc/cert/service/CertCfgService.java
@@ -25,6 +25,15 @@ public interface CertCfgService extends CrudService<CertCfg> {
   List<Map<String, String>> findEnabled4Option(String typeCode);
 
   /**
+   * 获取证件配置的选项列表
+   *
+   * @param statuses  证件配置的状态列表
+   * @param typeCodes 证件类别的编码列表
+   * @return 返回结果中的元素Map格式为：：key - CertCfg的code, value - CertCfg的name
+   */
+  List<Map<String, String>> find4Option(Integer[] statuses, String[] typeCodes);
+
+  /**
    * 获取证件配置信息
    *
    * @param typeCode

--- a/src/main/java/cn/bc/cert/service/CertCfgServiceImpl.java
+++ b/src/main/java/cn/bc/cert/service/CertCfgServiceImpl.java
@@ -28,6 +28,11 @@ public class CertCfgServiceImpl extends DefaultCrudService<CertCfg> implements C
     return this.certCfgDao.findEnabled4Option(typeCode);
   }
 
+  @Override
+  public List<Map<String, String>> find4Option(Integer[] statuses, String[] typeCodes) {
+    return certCfgDao.find4Option(statuses, typeCodes);
+  }
+
   public CertCfg loadByCode(String typeCode, String cfgCode) {
     return certCfgDao.loadByCode(typeCode, cfgCode);
   }


### PR DESCRIPTION
模块修改说明：

- 因为需要获取所有状态的司机证件选项，但是未有相关 service 接口，所以新增获取证件配置的选项列表 service 实现
- 修改根据证件类别获得所有证件的信息接口，保留已经上传的禁用证件历史信息